### PR TITLE
Removed profile_url from users table DDL

### DIFF
--- a/TABLES/CNDEMO_TWT_USERS_CRTB.sql
+++ b/TABLES/CNDEMO_TWT_USERS_CRTB.sql
@@ -10,7 +10,6 @@ CREATE TABLE CNDEMO_TWTR_USERS
 ,following_count     NUMBER NOT NULL
 ,tweet_count         NUMBER NOT NULL
 ,profile_image_url   VARCHAR2(100)
-,profile_url         VARCHAR2(100)
 ,extra_url           VARCHAR2(100)
 ,creation_date       TIMESTAMP WITH LOCAL TIME ZONE NOT NULL
 ,last_update_date    TIMESTAMP WITH LOCAL TIME ZONE NOT NULL


### PR DESCRIPTION
Hi Jon,

there is one attribute "profile_url" twice in the DDL.

And please have a look at the attribute "capture_id". It's missing in the "CNDEMO_TWTR_TWEETS" DDL, referenced in other DDL but not realy used in this table I guess.

cc